### PR TITLE
Possibility to have different ESP dirs with the same structure

### DIFF
--- a/sbupdate
+++ b/sbupdate
@@ -30,7 +30,7 @@ function error() {
 # Load configuration
 function load_config() {
   KEY_DIR="/root/secure-boot"
-  ESP_DIR="/boot"
+  ESP_DIR=('/boot')
   OUT_DIR="EFI/Arch"
   SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
   EXTRA_SIGN=()
@@ -38,7 +38,9 @@ function load_config() {
   # shellcheck disable=SC1090
   source "${CONFFILE}"
 
-  [[ -d "${ESP_DIR}" ]] || error "${ESP_DIR} does not exist"
+  for esp in ${ESP_DIR+"${ESP_DIR[@]}"}; do
+    [[ -d "${esp}" ]] || error "${esp} does not exist"
+  done
   [[ -n "${CMDLINE_DEFAULT:+x}" ]] \
     || error "CMDLINE_DEFAULT is not defined or empty in ${CONFFILE}"
 
@@ -130,13 +132,13 @@ function create_tmpfiles() {
 # Return output file path corresponding to a kernel
 #   $1: kernel name
 function output_name() {
-  echo "${ESP_DIR}/${OUT_DIR}/$1-signed.efi"
+  echo "$2/${OUT_DIR}/$1-signed.efi"
 }
 
 # Remove signed images corresponding to a kernel
 #   $1: kernel name
 function remove_kernel() {
-  local output; output="$(output_name "$1")"
+  local output; output="$(output_name "$1" "$2")"
 
   echo "Removing kernel image for $1..."
   rm -f "${output}" "${output}.bak"
@@ -148,7 +150,7 @@ function update_kernel() {
   local image="/boot/vmlinuz-$1"
   local cmdline="${CMDLINE[$1]:-${CMDLINE_DEFAULT}}"
   local initrd="${INITRD[$1]:-/boot/initramfs-$1.img}"
-  local output; output="$(output_name "$1")"
+  local output; output="$(output_name "$1" "$2")"
 
   echo "Generating and signing kernel image for $1..."
 
@@ -177,17 +179,17 @@ function update_kernel() {
     "${EFISTUB}" "${output}"
 
   # Sign the resulting output file
-  sbsign --key "${KEY_DIR}/DB.key" --cert "${KEY_DIR}/DB.crt" --output "${output}" "${output}"
+  sbsign --key "${KEY_DIR}/db.key" --cert "${KEY_DIR}/db.crt" --output "${output}" "${output}"
 }
 
 # Sign a user-specified extra file
 #   $1: file path
 function sign_extra_file() {
-  if sbverify --cert "${KEY_DIR}/DB.crt" "$1" >/dev/null 2>&1; then
+  if sbverify --cert "${KEY_DIR}/db.crt" "$1" >/dev/null 2>&1; then
     echo "Skipping already signed file $1"
   else
     echo "Signing $1..."
-    sbsign --key "${KEY_DIR}/DB.key" --cert "${KEY_DIR}/DB.crt" --output "$1" "$1"
+    sbsign --key "${KEY_DIR}/db.key" --cert "${KEY_DIR}/db.crt" --output "$1" "$1"
   fi
 }
 
@@ -202,12 +204,14 @@ function main() {
 
   create_tmpfiles
 
-  mkdir -p "${ESP_DIR}/${OUT_DIR}"
-  for k in ${OLD_KERNELS+"${OLD_KERNELS[@]}"}; do
-    remove_kernel "$k"
-  done
-  for k in ${KERNELS+"${KERNELS[@]}"}; do
-    update_kernel "$k"
+  for esp in ${ESP_DIR+"${ESP_DIR[@]}"}; do
+    mkdir -p "${esp}/${OUT_DIR}"
+    for k in ${OLD_KERNELS+"${OLD_KERNELS[@]}"}; do
+      remove_kernel "$k" "${esp}"
+    done
+    for k in ${KERNELS+"${KERNELS[@]}"}; do
+      update_kernel "$k" "${esp}"
+    done
   done
 
   if (( ! HOOK )); then


### PR DESCRIPTION
Hi andreyv,

For my archlinux system (2 hdd mount in raid1 for system with a ESP partition per hdd), i must modify sbupdate to use it because I have two distincts ESP partitions (1 main et the other for backup) with the same structure and i would upgrade the signed kernel at same time on both of them.
In sbupdate paramaters file (in /etc/default), I use ESP_DIR=('/boot/efi' '/boot/efi_backup') instead of ESP_DIR="/boot/efi".
With this modifications, you could always use only one ESP partition.

best regards

Sinseman44