### PR TITLE
Make creating of kernel backups optional

### DIFF
--- a/default
+++ b/default
@@ -10,6 +10,7 @@
 # SPLASH           Splash image file
 # EXTRA_SIGN       An array of additional files to sign
 # CMDLINE_DEFAULT  Default kernel command line (REQUIRED)
+# CREATE_BACKUP    Whether or not to create a kernel backup under OUT_DIR
 
 #KEY_DIR="/root/secure-boot"
 #ESP_DIR="/boot"
@@ -17,6 +18,7 @@
 #SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
 #EXTRA_SIGN=()
 #CMDLINE_DEFAULT=""
+#CREATE_BACKUP=true
 
 # Per-kernel configuration
 #

--- a/sbupdate
+++ b/sbupdate
@@ -34,6 +34,7 @@ function load_config() {
   OUT_DIR="EFI/Arch"
   SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
   EXTRA_SIGN=()
+  CREATE_BACKUP=true
   declare -g -A CMDLINE INITRD
   # shellcheck disable=SC1090
   source "${CONFFILE}"
@@ -153,7 +154,7 @@ function update_kernel() {
   echo "Generating and signing kernel image for $1..."
 
   # Back up existing file if present
-  if [[ -f "${output}" ]]; then
+  if ${CREATE_BACKUP} && [[ -f "${output}" ]]; then
     mv "${output}" "${output}.bak"
   fi
   


### PR DESCRIPTION
This change makes creation of kernel backups optional, using a new option in the default config file 'CREATE_BACKUP'. It defaults to "true", so existing functionality (always creating backups) does not change for users. This is helpful for folks, like myself, that have limited /boot size and have found ourselves unable to boot the system because sbupdate failed to create a new image due to not having enough free space on the partition to write a new image.