### PR TITLE
update vmlinuz location according to archlinux changes

### DIFF
--- a/sbupdate
+++ b/sbupdate
@@ -87,7 +87,7 @@ function find_efi_stub() {
 
 # Create a list of kernels to process
 function get_kernels() {
-  local all_kernels=(/boot/vmlinuz-*); all_kernels=("${all_kernels[@]#/boot/vmlinuz-}")
+  local all_kernels=$(cat /usr/lib/modules/*/pkgbase)
   local force_all=0
   declare -g -a KERNELS OLD_KERNELS
 
@@ -95,13 +95,13 @@ function get_kernels() {
     # The script was run from the hook. Read standard input to determine
     # which kernels we need to update.
     while read -r target; do
-      if [[ "${target}" =~ ^boot/vmlinuz-(.+)$ ]]; then
+      if [[ "${target}" =~ ^usr/lib/modules/(.+)$ ]]; then
         # Regular kernel
         if [[ ! -f "/${target}" ]]; then
           # We are removing this kernel
-          OLD_KERNELS+=("${BASH_REMATCH[1]}")
+          OLD_KERNELS+=$(cat /usr/lib/modules/"${BASH_REMATCH[1]}/pkgbase")
         else
-          KERNELS+=("${BASH_REMATCH[1]}")
+          KERNELS+=$(cat /usr/lib/modules/"${BASH_REMATCH[1]}/pkgbase")
         fi
       else
         # Another dependency; update all kernels
@@ -143,7 +143,7 @@ function remove_image() {
 #   $1: kernel name
 #   $2: initrd file name
 function update_image() {
-  local linux="/boot/vmlinuz-$1"
+  local linux=$(grep -l ${1} /usr/lib/modules/*/pkgbase); linux=${linux%%/pkgbase}/vmlinuz
   local cmdline="${CMDLINE[$1]:-${CMDLINE_DEFAULT}}"
   local output; output="$(output_name "$1" "$2")"
 

--- a/sbupdate.hook
+++ b/sbupdate.hook
@@ -3,7 +3,7 @@ Operation = Install
 Operation = Upgrade
 Operation = Remove
 Type = File
-Target = boot/vmlinuz-*
+Target = usr/lib/modules/*
 Target = usr/lib/initcpio/*
 
 [Trigger]


### PR DESCRIPTION
As discussed on the archlinux mailing list, archlinux is heading for a more modular initcpio packaging. The latest changes in the testing repo ~~move~~ remove the vmlinuz from /boot/vmlinuz-<kernel name> ~~to /usr/lib/modules/<kernel version>/vmlinuz~~. This PR adopts the ~~new~~ location change in the sbupdate script and in the pacman hook.