### PR TITLE
Add fwupd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ recommended for increased security.
 
 ## `fwupd` Compatibility
 
-`sbupdate` is now compatible with [`fwupd`](https://github.com/fwupd/fwupd), the Linux firmware update daemon. `fwupd`
-requires that the file, `/usr/lib/fwupd/efi/fwupdx64.efi.signed` be present *and* signed; 
-hence, `sbupdate` uses the keys and certificates found in `KEY_DIR` as defined in `/etc/sbupdate.conf` to sign the file 
-`/usr/lib/fwupd/fwupdx64.efi` (already provided by fwupd), and create `fwupdx64.efi.signed` in the same directory, using `sbsign`'s 
+`sbupdate` is now compatible with [`fwupd`](https://github.com/fwupd/fwupd), the Linux firmware update daemon. 
+
+`fwupd` requires that the file, `/usr/lib/fwupd/efi/fwupdx64.efi.signed` be present *and* signed. 
+Hence, `sbupdate` uses the keys and certificates found in `KEY_DIR` as defined in `/etc/sbupdate.conf` to sign the file 
+`/usr/lib/fwupd/fwupdx64.efi` (already provided by `fwupd`), and create `fwupdx64.efi.signed` in the same directory, using `sbsign`'s 
 [default behaviour](https://jlk.fjfi.cvut.cz/arch/manpages/man/sbsign.1).
 
 The script *mandates* that `fwupd` be installed *and* its corresponding `systemd` unit, `fwupd.service` be [enabled and running](https://wiki.archlinux.org/index.php/systemd#Using_units) to sign the file.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ need to be on the ESP before they are signed. It is customary to sign these
 files right after they have been installed on the ESP. Direct booting is
 recommended for increased security.
 
+## `fwupd` Compatibility
+
+`sbupdate` is now compatible with [`fwupd`](https://github.com/fwupd/fwupd), the Linux firmware update daemon. `fwupd' 
+requires that the file, `/usr/lib/fwupd/efi/fwupdx64.efi.signed` be present *and* signed; 
+hence, `sbupdate` uses the keys and certificates found in `KEY_DIR` as defined in `/etc/sbupdate.conf` to sign the file 
+`/usr/lib/fwupd/fwupdx64.efi` (already provided by fwupd), and create `fwupdx64.efi.signed` in the same directory, using `sbsign`'s 
+[default behaviour](https://jlk.fjfi.cvut.cz/arch/manpages/man/sbsign.1).
+
+The script *mandates* that `fwupd` be installed *and* its corresponding `systemd` unit, `fwupd.service` be [enabled and running](https://wiki.archlinux.org/index.php/systemd#Using_units) to sign the file.
+
 ## Related resources
 
 * https://wiki.archlinux.org/index.php/Unified_Extensible_Firmware_Interface

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ recommended for increased security.
 
 ## `fwupd` Compatibility
 
-`sbupdate` is now compatible with [`fwupd`](https://github.com/fwupd/fwupd), the Linux firmware update daemon. `fwupd' 
+`sbupdate` is now compatible with [`fwupd`](https://github.com/fwupd/fwupd), the Linux firmware update daemon. `fwupd`
 requires that the file, `/usr/lib/fwupd/efi/fwupdx64.efi.signed` be present *and* signed; 
 hence, `sbupdate` uses the keys and certificates found in `KEY_DIR` as defined in `/etc/sbupdate.conf` to sign the file 
 `/usr/lib/fwupd/fwupdx64.efi` (already provided by fwupd), and create `fwupdx64.efi.signed` in the same directory, using `sbsign`'s 

--- a/sbupdate
+++ b/sbupdate
@@ -134,6 +134,30 @@ function remove_image() {
   fi
 }
 
+# Check for presence of fwupd package AND if fwupd module is enabled.
+#   If so, sign the fwupd image, /usr/lib/fwupd/efi/fwupdx64.efi as fwupdx64.efi.signed.
+#   Use sbsign default behaviour for this, as demanded by fwupd.
+#
+#   This function is necessary because the naming convention of
+#   fwupd has ".signed" at the end of the image file.
+function sign_fwupd() {
+  local img_name="fwupdx64.efi"
+  local fwupd_dir="/usr/lib/fwupd/efi"
+  if (( pacman -Qi fwupd > /dev/null ) && ( systemctl is-active --quiet fwupd )); then
+    echo "fwupd package is installed, and service is running."
+    if sbverify --cert "${KEY_DIR}"/@(DB|db).crt "${fwupd_dir}/${img_name}".signed > /dev/null; then
+      echo "Skipping already signed file ${fwupd_dir}/${img_name}."
+    else
+      # Sign the fwupd image file.
+      echo "Signing ${fwupd_dir}/${img_name}."
+      sbsign --key "${KEY_DIR}"/@(DB|db).key --cert "${KEY_DIR}"/@(DB|db).crt "${fwupd_dir}/${img_name}"
+      # Restart the fwupd service.
+      echo "Restarting fwupd.service."
+      systemctl restart fwupd.service --quiet > /dev/null
+    fi
+  fi
+}
+
 # Generate a signed kernel image
 #   $1: image name
 #   $2: kernel location
@@ -209,6 +233,8 @@ function main() {
   for f in "${EXTRA_SIGN[@]}"; do
     check_sign_extra_file "$f"
   done
+
+  sign_fwupd
 }
 
 main "$@"


### PR DESCRIPTION
A function, `sign_fwupd` is added.

This function firstly checks that `fwupd` is installed and the service running. If so, the function checks if `/usr/lib/fwupd/efi/fwupdx64.efi.signed` exists, and exits if true. Otherwise, the signed file is generated with the user’s keys, and `fwupd.service` is restarted.