### PR TITLE
Add option to rename installed kernel image to "grubx64.efi"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ automatically.
 
 💡 _Hint_: Disable boot splash to keep the UEFI boot logo.
 
+💡 _Hint_: Specify AS_GRUBX64EFI=_kernel-image_ to rename that kernel to "grubx64.efi" during installation to the ESP (required when using Shim as bootloader).
+
 
 ## Direct booting vs. boot manager
 

--- a/sbupdate
+++ b/sbupdate
@@ -36,6 +36,7 @@ function load_config() {
   OUT_DIR="EFI/Arch"
   SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
   BACKUP=1
+  AS_GRUBX64EFI=""
   EXTRA_SIGN=()
   declare -g -A CONFIGS CMDLINE INITRD
 
@@ -53,7 +54,7 @@ function load_config() {
   local key=("${KEY_DIR}"/@(DB|db).key); readonly KEY="${key[0]}"
   local cert=("${KEY_DIR}"/@(DB|db).crt); readonly CERT="${cert[0]}"
 
-  readonly KEY_DIR ESP_DIR OUT_DIR SPLASH BACKUP EXTRA_SIGN INITRD_PREPEND CMDLINE_DEFAULT
+  readonly KEY_DIR ESP_DIR OUT_DIR SPLASH BACKUP EXTRA_SIGN INITRD_PREPEND CMDLINE_DEFAULT AS_GRUBX64EFI
   readonly -A CONFIGS CMDLINE INITRD
 }
 
@@ -171,6 +172,10 @@ function update_image() {
 
   # Sign the resulting output file
   sign_file --output "${output}" "${output}"
+
+  if [ "$1" == "$AS_GRUBX64EFI" ] ; then
+    cp "${output}" "$(dirname ${output})/grubx64.efi"
+  fi
 }
 
 # Map kernel versions to image names and process changes

--- a/sbupdate.conf
+++ b/sbupdate.conf
@@ -9,6 +9,7 @@
 # OUT_DIR          Relative path on ESP for signed kernel images
 # SPLASH           Splash image file. Use "/dev/null" to disable splash.
 # BACKUP           Whether to back up old signed kernel images
+# AS_GRUBX64EFI    Which kernel image to rename to "grubx64.efi" during install.
 # EXTRA_SIGN       An array of additional files to sign
 # CMDLINE_DEFAULT  Default kernel command line (REQUIRED)
 
@@ -17,6 +18,7 @@
 #OUT_DIR="EFI/Arch"
 #SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
 #BACKUP=1
+#AS_GRUB64EFI=""
 #EXTRA_SIGN=()
 #CMDLINE_DEFAULT=""
 

--- a/sbupdate.conf
+++ b/sbupdate.conf
@@ -18,7 +18,7 @@
 #OUT_DIR="EFI/Arch"
 #SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
 #BACKUP=1
-#AS_GRUB64EFI=""
+#AS_GRUBX64EFI=""
 #EXTRA_SIGN=()
 #CMDLINE_DEFAULT=""
 


### PR DESCRIPTION
Some people use Shim as a bootloader to boot other bootloaders signed by their own MOK key. Since Shim is hardcoded to boot "grubx64.efi", a new configuration argument "AS_GRUBX64EFI" determines which kernel, if any, gets a copy by the name of "grubx64.efi" in the ESP.
To prevent an unbootable system, "grubx64.efi" doesn't get removed when the script is invoked to remove a kernel, instead we wait until a new kernel is installed to replace "grubx64.efi" if required.