### PR TITLE
add additional alpm triggers

### DIFF
--- a/hooks/95-sbupdate.hook
+++ b/hooks/95-sbupdate.hook
@@ -10,6 +10,9 @@ Operation = Upgrade
 Operation = Remove
 Type = Path
 Target = usr/lib/initcpio/*
+Target = usr/src/*/dkms.conf
+Target = usr/lib/modules/*/build/include/
+Target = usr/lib/modules/*/modules.alias
 
 [Trigger]
 Operation = Install


### PR DESCRIPTION
fix alpm triggers to run on dkms module installs and other mkinitcpio installs

Fixes andreyv/sbupdate#44