### PR TITLE
Added support for no default kernel parameters

### DIFF
--- a/sbupdate
+++ b/sbupdate
@@ -47,8 +47,7 @@ function load_config() {
   source "${CONFFILE}"
 
   [[ -d "${ESP_DIR}" ]] || error "${ESP_DIR} does not exist"
-  [[ -n "${CMDLINE_DEFAULT:+x}" ]] \
-    || error "CMDLINE_DEFAULT is not defined or empty in ${CONFFILE}"
+  CMDLINE_DEFAULT="${CMDLINE_DEFAULT:-}"
 
   local key=("${KEY_DIR}"/@(DB|db).key); readonly KEY="${key[0]}"
   local cert=("${KEY_DIR}"/@(DB|db).crt); readonly CERT="${cert[0]}"

--- a/sbupdate.conf
+++ b/sbupdate.conf
@@ -10,7 +10,7 @@
 # SPLASH           Splash image file. Use "/dev/null" to disable splash.
 # BACKUP           Whether to back up old signed kernel images
 # EXTRA_SIGN       An array of additional files to sign
-# CMDLINE_DEFAULT  Default kernel command line (REQUIRED)
+# CMDLINE_DEFAULT  Default kernel command line. Leave empty to disable.
 
 #KEY_DIR="/etc/efi-keys"
 #ESP_DIR="/boot"


### PR DESCRIPTION
This way it's helpful for boot managers like rEFInd that can set multiple boot options with different kernel params.

For example, I have set up a boot option in rEFInd for booting into emergency mode. I can't use this boot option, since the unified image will reject what rEFInd passes it and only use the hardcoded options. The only way is to disable secure boot and re-enable after I'm done using emergency mode.

With these changes, if both the per-config and default command lines are empty, then `sbupdate` should set an empty command line. This is basically ignored by the EFI, and thus it will allow rEFInd to pass its options.

I've tested this with both cases of setting a command line and not setting any, and my system (EFI firmware in the Asus ROG GL552VW with the latest BIOS update) boots fine.