### PR TITLE
Add support for EncFS

### DIFF
--- a/sbupdate
+++ b/sbupdate
@@ -35,6 +35,7 @@ function load_config() {
   ESP_DIR="/boot"
   OUT_DIR="EFI/Arch"
   SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
+  ENCRYPTED=0
   BACKUP=1
   EXTRA_SIGN=()
   declare -g -A CONFIGS CMDLINE INITRD OUTPUT
@@ -51,10 +52,17 @@ function load_config() {
   [[ -d "${ESP_DIR}" ]] || error "${ESP_DIR} does not exist"
   [[ -n "${CMDLINE_DEFAULT:+x}" ]] || error "CMDLINE_DEFAULT is not defined or empty"
 
+  if (( ENCRYPTED )); then
+    DEC_DIR="/tmp/efi-keys"
+    mkdir "${DEC_DIR}"
+    while true; do encfs "${KEY_DIR}" "${DEC_DIR}" && break; done
+    KEY_DIR="${DEC_DIR}"
+  fi
+
   local key=("${KEY_DIR}"/@(DB|db).key); readonly KEY="${key[0]}"
   local cert=("${KEY_DIR}"/@(DB|db).crt); readonly CERT="${cert[0]}"
 
-  readonly KEY_DIR ESP_DIR OUT_DIR SPLASH BACKUP EXTRA_SIGN INITRD_PREPEND CMDLINE_DEFAULT
+  readonly KEY_DIR ESP_DIR OUT_DIR SPLASH ENCRYPTED BACKUP EXTRA_SIGN INITRD_PREPEND CMDLINE_DEFAULT
   readonly -A CONFIGS CMDLINE INITRD OUTPUT
 }
 
@@ -234,6 +242,11 @@ function main() {
   for f in "${EXTRA_SIGN[@]}"; do
     check_sign_extra_file "$f"
   done
+
+  if (( ENCRYPTED )); then
+    encfs -u "${KEY_DIR}" > /dev/null
+    rmdir "${KEY_DIR}"
+  fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi

--- a/sbupdate
+++ b/sbupdate
@@ -53,10 +53,10 @@ function load_config() {
   [[ -n "${CMDLINE_DEFAULT:+x}" ]] || error "CMDLINE_DEFAULT is not defined or empty"
 
   if (( ENCRYPTED )); then
-    DEC_DIR="/tmp/efi-keys"
-    mkdir "${DEC_DIR}"
-    while true; do encfs "${KEY_DIR}" "${DEC_DIR}" && break; done
-    KEY_DIR="${DEC_DIR}"
+    local decrypt="/tmp/efi-keys"
+    mkdir "${decrypt}"
+    while true; do encfs "${KEY_DIR}" "${decrypt}" && break; done
+    KEY_DIR="${decrypt}"
   fi
 
   local key=("${KEY_DIR}"/@(DB|db).key); readonly KEY="${key[0]}"

--- a/sbupdate.conf
+++ b/sbupdate.conf
@@ -8,6 +8,7 @@
 # ESP_DIR          EFI System Partition location
 # OUT_DIR          Relative path on ESP for signed kernel images
 # SPLASH           Splash image file. Use "/dev/null" to disable splash.
+# ENCRYPTED        Whether files in KEY_DIR are encrypted with EncFS
 # BACKUP           Whether to back up old signed kernel images
 # EXTRA_SIGN       An array of additional files to sign
 # CMDLINE_DEFAULT  Default kernel command line. Read from /etc/kernel/cmdline
@@ -17,6 +18,7 @@
 #ESP_DIR="/boot"
 #OUT_DIR="EFI/Arch"
 #SPLASH="/usr/share/systemd/bootctl/splash-arch.bmp"
+#ENCRYPTED=0
 #BACKUP=1
 #EXTRA_SIGN=()
 #CMDLINE_DEFAULT=""


### PR DESCRIPTION
Leaving the keys in `/etc/efi-keys` unprotected kinda defeats the purpose of SecureBoot, so I've added  support for [EncFS](https://github.com/vgough/encfs).